### PR TITLE
Refactor agent activation and improve path handling

### DIFF
--- a/audio_player.py
+++ b/audio_player.py
@@ -12,6 +12,8 @@ from mutagen.mp3 import MP3
 from pydub import AudioSegment
 from rich import print
 
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
 class AudioManager:
 
     # Variables for recording audio from mic
@@ -47,7 +49,7 @@ class AudioManager:
                 # Some wav files don't work with Pygame's Music for some reason (works fine with Sound)
                 # If there's an error here that's likely why, so convert it to a format that Pygame can handle
                 # You can't convert the file in place so just convert it into a temp file that you delete later
-                converted_wav = "temp_convert.wav"
+                converted_wav = os.path.join(BASE_DIR, "temp_convert.wav")
                 subprocess.run(["ffmpeg", "-y", "-i", file_path, "-ar", "48000", "-ac", "2", "-c:a", "pcm_s16le", converted_wav])
                 converted = True
                 pygame.mixer.music.load(converted_wav)
@@ -106,7 +108,7 @@ class AudioManager:
     
     def combine_audio_files(self, input_files):
         # input_files is an array of file paths
-        output_file = os.path.join(os.path.abspath(os.curdir), f"___Msg{str(hash(' '.join(input_files)))}.wav")
+        output_file = os.path.join(BASE_DIR, f"___Msg{str(hash(' '.join(input_files)))}.wav")
         combined = None
         for file in input_files:
             audio = AudioSegment.from_file(file)
@@ -175,7 +177,7 @@ class AudioManager:
         self.is_recording = False
         time.sleep(0.1) # Just for safety, no clue if this is needed
 
-        filename = f"mic_recording_{int(time.time())}.wav"
+        filename = os.path.join(BASE_DIR, f"mic_recording_{int(time.time())}.wav")
         wave_file = wave.open(filename, 'wb')
         wave_file.setnchannels(self.channels)
         wave_file.setsampwidth(audio.get_sample_size(self.audio_format))

--- a/coqui_tts.py
+++ b/coqui_tts.py
@@ -22,7 +22,8 @@ class CoquiTTSManager:
         self.speaker_wav = os.getenv("SPEAKER_WAV", "").strip()
 
         out_dir = os.getenv("AUDIO_OUT_DIR", "audio_out")
-        self.output_dir = os.path.join(os.path.abspath(os.curdir), "static", out_dir)
+        base_dir = os.path.dirname(os.path.abspath(__file__))
+        self.output_dir = os.path.join(base_dir, "static", out_dir)
         os.makedirs(self.output_dir, exist_ok=True)
 
     def text_to_audio(self, input_text: str, voice: str = "", save_as_wave: bool = True,

--- a/obs_websockets.py
+++ b/obs_websockets.py
@@ -25,11 +25,14 @@ class OBSWebsocketsManager:
     def set_filter_visibility(self, source_name, filter_name, filter_enabled=True):
         self.ws.call(requests.SetSourceFilterEnabled(sourceName=source_name, filterName=filter_name, filterEnabled=filter_enabled))
 
+    def _get_scene_item_id(self, scene_name, source_name):
+        response = self.ws.call(requests.GetSceneItemId(sceneName=scene_name, sourceName=source_name))
+        return response.datain['sceneItemId']
+
     # Set the visibility of any source
     def set_source_visibility(self, scene_name, source_name, source_visible=True):
-        response = self.ws.call(requests.GetSceneItemId(sceneName=scene_name, sourceName=source_name))
-        myItemID = response.datain['sceneItemId']
-        self.ws.call(requests.SetSceneItemEnabled(sceneName=scene_name, sceneItemId=myItemID, sceneItemEnabled=source_visible))
+        my_item_id = self._get_scene_item_id(scene_name, source_name)
+        self.ws.call(requests.SetSceneItemEnabled(sceneName=scene_name, sceneItemId=my_item_id, sceneItemEnabled=source_visible))
 
     # Returns the current text of a text source
     def get_text(self, source_name):
@@ -41,9 +44,8 @@ class OBSWebsocketsManager:
         self.ws.call(requests.SetInputSettings(inputName=source_name, inputSettings = {'text': new_text}))
 
     def get_source_transform(self, scene_name, source_name):
-        response = self.ws.call(requests.GetSceneItemId(sceneName=scene_name, sourceName=source_name))
-        myItemID = response.datain['sceneItemId']
-        response = self.ws.call(requests.GetSceneItemTransform(sceneName=scene_name, sceneItemId=myItemID))
+        my_item_id = self._get_scene_item_id(scene_name, source_name)
+        response = self.ws.call(requests.GetSceneItemTransform(sceneName=scene_name, sceneItemId=my_item_id))
         transform = {}
         transform["positionX"] = response.datain["sceneItemTransform"]["positionX"]
         transform["positionY"] = response.datain["sceneItemTransform"]["positionY"]
@@ -66,9 +68,8 @@ class OBSWebsocketsManager:
     # Note: there are other transform settings, like alignment, etc, but these feel like the main useful ones.
     # Use get_source_transform to see the full list
     def set_source_transform(self, scene_name, source_name, new_transform):
-        response = self.ws.call(requests.GetSceneItemId(sceneName=scene_name, sourceName=source_name))
-        myItemID = response.datain['sceneItemId']
-        self.ws.call(requests.SetSceneItemTransform(sceneName=scene_name, sceneItemId=myItemID, sceneItemTransform=new_transform))
+        my_item_id = self._get_scene_item_id(scene_name, source_name)
+        self.ws.call(requests.SetSceneItemTransform(sceneName=scene_name, sceneItemId=my_item_id, sceneItemTransform=new_transform))
 
     # Note: an input, like a text box, is a type of source. This will get *input-specific settings*, not the broader source settings like transform and scale
     # For a text source, this will return settings like its font, color, etc

--- a/scripts/smoke_tts.py
+++ b/scripts/smoke_tts.py
@@ -28,7 +28,8 @@ def main():
         if opened:
             opened.close()
 
-    out_dir = os.path.join(os.path.abspath(os.curdir), 'static', os.getenv('AUDIO_OUT_DIR', 'audio_out'))
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    out_dir = os.path.abspath(os.path.join(base_dir, '..', 'static', os.getenv('AUDIO_OUT_DIR', 'audio_out')))
     os.makedirs(out_dir, exist_ok=True)
     out_path = os.path.join(out_dir, 'test.wav')
     with open(out_path, 'wb') as f:


### PR DESCRIPTION
## Summary
- Dynamically handle agent activation based on number keys
- Improve subtitle loop error handling and audio URL generation
- Use script-relative paths for audio files and refactor OBS scene item lookup

## Testing
- `python -m py_compile multi_agent_gpt.py coqui_tts.py audio_player.py obs_websockets.py scripts/smoke_tts.py`
- `pytest -q`
- `python scripts/preflight.py` *(fails: connection refused to local services)*

------
https://chatgpt.com/codex/tasks/task_e_68959bf490a4832f86ca421442dad498